### PR TITLE
increase volume and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To set-up the instance:
 ```
 cp vars.yaml $USER.yaml
 vim $USER.yaml
+vim roles/spawn/defaults/main.yaml # modify the prefix to be your alias
+# upload your public key to AWS and name it test-{{ prefix }}
 export RHSM_LOGIN="your-RHSM-login"
 export RHSM_PASSWORD="your-RHSM-password"
 ansible-playbook -vvv deploy.yaml -e @vars.yaml

--- a/roles/spawn/tasks/main.yaml
+++ b/roles/spawn/tasks/main.yaml
@@ -67,7 +67,7 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_size: 32
+          volume_size: 64
           delete_on_termination: true
     wait: true
     state: running
@@ -86,4 +86,4 @@
     ansible_host: '{{ instance_info.instances[0].public_ip_address }}'
     ansible_user: ec2-user
     ansible_host_key_checking: false
-    ansible_ssh_private_key_file: "{{ my_ssh_pub_key }}"
+    ansible_ssh_private_key_file: "{{ my_ssh_private_key }}"

--- a/roles/spawn/tasks/main.yaml
+++ b/roles/spawn/tasks/main.yaml
@@ -55,6 +55,7 @@
 - name: start an instance with a public IP address
   amazon.aws.ec2_instance:
     name: "{{ instance_name }}"
+    termination_protection: true
     key_name: "{{ keypair_name }}"
     instance_type: g4dn.2xlarge
     vpc_subnet_id: "{{ subnet.subnet.id }}"

--- a/vars.yaml
+++ b/vars.yaml
@@ -4,4 +4,5 @@ aws_region: ca-central-1
 aws_az: ca-central-1b
 wisdom_mar_path: /home/goneri/git_repos/wisdom/model/wisdom/wisdom.mar
 my_ssh_pub_key: /home/goneri/.ssh/id_rsa.pub  # Need to be a RSA key
+my_ssh_private_key: /home/goneri/.ssh/id_rsa
 add_gpu_host_in_ssh_config: false


### PR DESCRIPTION
- Update README to include keypair steps and changing the prefix
- Pass the private key file to ansible_ssh_private_key_file
- Double the volume size. I tried to use this VM to also run the model server directly (no container) and ran out of space. Having the option to run either way is nice.